### PR TITLE
Null Scenes and Input

### DIFF
--- a/src/main/java/suga/engine/game/BasicGame.java
+++ b/src/main/java/suga/engine/game/BasicGame.java
@@ -12,7 +12,6 @@ import suga.engine.physics.BasicPhysicsEngine;
 import suga.engine.physics.PhysicsEngine;
 import suga.engine.physics.collidables.Collidable;
 import suga.engine.threads.SugaThread;
-import suga.engine.graphics.GraphicsPanelInterface;
 import suga.engine.input.keyboard.GameKeyListener;
 import suga.engine.input.keyboard.KeyValue;
 
@@ -159,6 +158,10 @@ public class BasicGame implements Game {
      */
     @Override
     public void processInput () {
+        if (loadedScene == null) {
+            GameEngine.getLogger().log("BasicGame: No loaded scene. Cannot process inputs.", Level.WARNING);
+            return;
+        }
         Stack<MouseEvent> mice = mouseListener.getEvents();
         while (mice.size() > 0) {
             MouseEvent e = mice.pop();

--- a/src/main/java/suga/engine/game/objects/BasicGameObject.java
+++ b/src/main/java/suga/engine/game/objects/BasicGameObject.java
@@ -35,10 +35,8 @@ public class BasicGameObject extends BasicPhysical implements DrawListener, Game
     /**
      * Called every logic frame to run the logic on this GameObject.
      */
-    @Deprecated // Physics engine will update object positions now using Physical.update();
     public void runLogic () {
-//        pos.add(velocity);
-//        if (velocity.magnitude() < 25 && accel.magnitude() > 0 || velocity.magnitude() > 25 && accel.magnitude() < 0) velocity.add(accel);
+
     }
 
     /**

--- a/src/main/java/suga/engine/graphics/GraphicsPanel.java
+++ b/src/main/java/suga/engine/graphics/GraphicsPanel.java
@@ -69,7 +69,7 @@ public abstract class GraphicsPanel extends JPanel implements GraphicsPanelInter
     }
 
     /**
-     * Adds the drawing listener to this Graphics2d instance.
+     * Adds the drawing listener to this instance.
      *
      * @param listener The listener to register.
      */
@@ -78,7 +78,7 @@ public abstract class GraphicsPanel extends JPanel implements GraphicsPanelInter
     }
 
     /**
-     * Adds the drawing listener to this Graphics2d instance with the given priority.
+     * Adds the drawing listener to this instance with the given priority.
      *
      * @param priority The priority to register the listener at.
      * @param listener The listener to register.

--- a/src/main/java/suga/engine/graphics/GraphicsPanelInterface.java
+++ b/src/main/java/suga/engine/graphics/GraphicsPanelInterface.java
@@ -28,14 +28,14 @@ public interface GraphicsPanelInterface {
     void setThread (SugaThread thread);
 
     /**
-     * Adds the drawing listener to this Graphics2d instance.
+     * Adds the drawing listener to this instance.
      *
      * @param listener The listener to register.
      */
     void registerListener (DrawListener listener);
 
     /**
-     * Adds the drawing listener to this Graphics2d instance with the given priority.
+     * Adds the drawing listener to this instance with the given priority.
      *
      * @param priority The priority to register the listener at.
      * @param listener The listener to register.

--- a/src/main/java/suga/engine/threads/GameLogicThread.java
+++ b/src/main/java/suga/engine/threads/GameLogicThread.java
@@ -1,5 +1,6 @@
 package suga.engine.threads;
 
+import suga.engine.GameEngine;
 import suga.engine.game.Game;
 
 /**
@@ -90,12 +91,18 @@ public class GameLogicThread extends Thread implements SugaThread {
                     //noinspection BusyWait
                     sleep((1000 / LOGIC_RATE) - logicTime);
                 } catch (Exception e) {
-                    e.printStackTrace();
+                    GameEngine.getLogger().log(e);
                 }
             }
             lastFinished = System.currentTimeMillis();
             game.processInput();
-            if (!paused) game.loop();
+            if (!paused) {
+                try {
+                    game.loop();
+                } catch (Exception e) {
+                    GameEngine.getLogger().log(e);
+                }
+            }
         }
     }
 }

--- a/src/main/java/suga/engine/threads/GraphicsThread.java
+++ b/src/main/java/suga/engine/threads/GraphicsThread.java
@@ -1,5 +1,6 @@
 package suga.engine.threads;
 
+import suga.engine.GameEngine;
 import suga.engine.graphics.GraphicsPanel;
 
 /**
@@ -101,11 +102,17 @@ public class GraphicsThread extends Thread implements SugaThread {
                     //noinspection BusyWait
                     sleep((int) ((1000 / FRAME_RATE) - drawTime));
                 } catch (Exception e) {
-                    e.printStackTrace();
+                    GameEngine.getLogger().log(e);
                 }
             }
             lastFinished = System.currentTimeMillis();
-            if (!paused) panel.repaint();
+            if (!paused) {
+                try {
+                    panel.repaint();
+                } catch (Exception e) {
+                    GameEngine.getLogger().log(e);
+                }
+            }
             frames++;
         }
     }

--- a/src/test/java/suga/engine/game/BasicGameTest.java
+++ b/src/test/java/suga/engine/game/BasicGameTest.java
@@ -2,13 +2,11 @@ package suga.engine.game;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 import suga.engine.game.objects.AIAgent;
 import suga.engine.game.objects.GameObject;
 import suga.engine.graphics.GraphicsPanel;
 import suga.engine.input.mouse.BasicMouseListener;
 import suga.engine.physics.BasicPhysicsEngine;
-import suga.engine.graphics.DrawListener;
 import suga.engine.input.keyboard.GameKeyListener;
 import suga.engine.physics.PhysicsEngine;
 import suga.engine.threads.SugaThread;
@@ -112,6 +110,7 @@ class BasicGameTest {
         when(game.getMouseListener().getEvents()).thenReturn(new Stack<>());
         when(game.keyListener.getKeyPresses()).thenReturn(new Stack<>());
         when(game.keyListener.getKeyReleases()).thenReturn(new Stack<>());
+        game.loadedScene = mock(Scene.class);
         game.processInput();
         verify(game.getMouseListener(), times(1)).getEvents();
         verify(game.keyListener, times(1)).getKeyPresses();
@@ -183,10 +182,8 @@ class BasicGameTest {
         game.addGameObject("obj", o);
         AIAgent a = mock(AIAgent.class);
         game.addAgent(a);
-        GraphicsPanel p = mock(GraphicsPanel.class);
-        game.panel = p;
+        game.panel = mock(GraphicsPanel.class);
         game.clear();
-//        verify(p, times(1)).clearListeners(); // todo
         assertNull(game.getGameObject("obj"), "Game should no longer contain added object after clear.");
         assertFalse(game.agents.contains(a), "Game should no longer contain added AIAgent after clear.");
         assertNotEquals(physics, game.physics, "Game should have a fresh physics system after clear.");


### PR DESCRIPTION
- Added null check for processing input on loadedScene in BasicGame.
- Removed deprecation and unused code in BasicGameObject.runLogic(). runLogic() is called every tick in BasicGame.
- Added exception checking in both graphics and game logic threads which simply prints to the logger and continues.
- Updated documentation in GraphicsPanel and GraphicsPanelInterface.
- Assigned a mock scene as the loaded scene for the tested game.

Fixes #23 